### PR TITLE
Fix incorrect links in section 3.4 of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,8 +536,8 @@ in this case.
 
 Reference:
 
-- [AppFlip.js](./public/scripts/AppDraggable.js)
-- [TodoApp.js](./public/scripts/AppSortable.js)
+- [AppFlip.js](./public/scripts/AppFlip.js)
+- [TodoApp.js](./public/scripts/TodoApp.js)
 
 ## 4. Testing
 


### PR DESCRIPTION
These links were the same as the first two links in section 3.3 – probably a copy-paste error.